### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -164,7 +164,12 @@ class MotionBuilderEngine(tank.platform.Engine):
         self._menu_generator = tk_motionbuilder.MenuGenerator(self, menu_name)
         self._menu_generator.create_menu()
 
-        self.log_user_attribute_metric("Motionbuilder version", str(FBSystem().Version))
+        try:
+            self.log_user_attribute_metric("Motionbuilder version",
+                str(FBSystem().Version))
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
     def destroy_engine(self):
         self.log_debug('%s: Destroying...' % self)

--- a/engine.py
+++ b/engine.py
@@ -164,6 +164,8 @@ class MotionBuilderEngine(tank.platform.Engine):
         self._menu_generator = tk_motionbuilder.MenuGenerator(self, menu_name)
         self._menu_generator.create_menu()
 
+        self.log_user_attribute_metric("Motionbuilder version", str(FBSystem().Version))
+
     def destroy_engine(self):
         self.log_debug('%s: Destroying...' % self)
         self._menu_generator.destroy_menu()

--- a/info.yml
+++ b/info.yml
@@ -49,4 +49,3 @@ description: "Shotgun Integration in Motionbuilder"
 requires_shotgun_version:
 requires_core_version: "v0.14.23"
 
-# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -48,3 +48,5 @@ description: "Shotgun Integration in Motionbuilder"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.14.23"
+
+# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.