### PR TITLE
SG-6429 ensure that the folder exists before saving.

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -350,8 +350,7 @@ def _save_session(path):
     Save the current session to the supplied path.
     """
     # Motionbuilder won't ensure that the folder is created when saving, so we must make sure it exists
-    folder = os.path.dirname(path)
-    ensure_folder_exists(folder)
+    ensure_folder_exists(os.path.dirname(path))
 
     mb_app.FileSave(path)
 

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -10,6 +10,7 @@
 
 import os
 import sgtk
+from sgtk.util.filesystem import ensure_folder_exists
 
 from pyfbsdk import FBApplication, FBFilePopup, FBFilePopupStyle
 
@@ -348,6 +349,9 @@ def _save_session(path):
     """
     Save the current session to the supplied path.
     """
+    # Motionbuilder won't ensure that the folder is created when saving, so we must make sure it exists
+    folder = os.path.dirname(path)
+    ensure_folder_exists(folder)
 
     mb_app.FileSave(path)
 


### PR DESCRIPTION
Makes sure that the folder exists before saving the workfile. This fixes a bug that would occur if you had folder that would get dynamically created with each save, such as having a version folder in your save template.