### PR TITLE
Motionbuilder 2019 support

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -39,7 +39,7 @@ def tank_mobu_exception_trap(ex_cls, ex, tb):
 
     # now output it    
     try:
-        from PySide import QtGui
+        from sgtk.platform.qt import QtCore, QtGui
         QtGui.QMessageBox.critical(None, "Python Exception Raised", error_message)
     except:
         try:
@@ -104,7 +104,7 @@ class MotionBuilderEngine(tank.platform.Engine):
 
         # first see if pyside is already present - in that case skip!
         try:
-            from PySide import QtGui
+            from sgtk.platform.qt import QtCore, QtGui
         except:
             # fine, we don't expect pyside to be present just yet
             self.log_debug("PySide not detected - it will be added to the setup now...")
@@ -159,7 +159,7 @@ class MotionBuilderEngine(tank.platform.Engine):
         
         :returns: QWidget if found or None if not
         """
-        from PySide import QtGui
+        from sgtk.platform.qt import QtCore, QtGui
         
         # get all top level windows:
         top_level_windows = QtGui.QApplication.topLevelWidgets()

--- a/engine.py
+++ b/engine.py
@@ -128,7 +128,7 @@ class MotionBuilderEngine(tank.platform.Engine):
 
         # now try to import it
         try:
-            from PySide import QtCore
+            from sgtk.platform.qt import QtCore, QtGui
         except Exception, e:
             self.log_error("PySide could not be imported! Apps using pyside will not "
                            "operate correctly! Error reported: %s" % e)
@@ -141,7 +141,7 @@ class MotionBuilderEngine(tank.platform.Engine):
 
         :param: pyside_folder Filesystem location where the plugins live
         """
-        from PySide import QtCore
+        from sgtk.platform.qt import QtCore, QtGui
 
         plugin_path = os.path.join(self.disk_location, "resources", pyside_folder, "qt_plugins")
 


### PR DESCRIPTION
Motionbuilder 2019 has moved to PySide2.
Change is to the engine.py to use `from sgtk.platform.qt import QtCore, QtGui` wrapper instead of calling PySide directly