### PR TITLE
SG-15106 - Support for MotionBuilder 2020

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -37,5 +37,5 @@ description: "Shotgun Integration in Motionbuilder"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.23"
+requires_core_version: "v0.18.172"
 


### PR DESCRIPTION
And updated version of tk-core is required to be able to support our integration in MotionBuilder 2020