### PR TITLE
Removed PySide from the software credits list.

### DIFF
--- a/software_credits
+++ b/software_credits
@@ -1,11 +1,5 @@
 The Motionbuilder engine uses the following software. Thanks to their creators, license information below.
 
-============================== PYSIDE ==============================
-
-PySide has been published as a response to the lack of suitably licensed Qt bindings for Python.
-PySide is licensed under the LGPL version 2.1 license, allowing both Free/Open source software
-and proprietary software development.
-
 ============================== Qt ==============================
 
 Qt can be used under open source (GPL v3 and LGPL v2.1)


### PR DESCRIPTION
I've left the QT credits as we bundle some Qt dls however I wasn't certain on whether to leave the Qt credits as they are or put the full licence in.