### PR TITLE
SG-35172 Remove software_credits file -  no copy of any third party software

### DIFF
--- a/software_credits
+++ b/software_credits
@@ -1,5 +1,0 @@
-The Motionbuilder engine uses the following software. Thanks to their creators, license information below.
-
-============================== Qt ==============================
-
-Qt can be used under open source (GPL v3 and LGPL v2.1)


### PR DESCRIPTION
This component does not include or ship any copy of third-party software. 

Revert 3cca78b

This file has never been added to the https://github.com/shotgunsoftware/tk-desktop/blob/master/python/tk_desktop/licenses.html so removing it will not create a dead-link.
