### PR TITLE
SG-42789 support motionbuilder 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for MotionBuilder
 
-![Supported MotionBuilder: 2023 - 2026](https://img.shields.io/badge/MotionBuilder-2026_|_2025_|_2024_|_2023-blue?logo=autodesk "Supported MotionBuilder versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+![Supported MotionBuilder: 2024 - 2027](https://img.shields.io/badge/MotionBuilder-2027_|_2026_|_2025_|_2024-blue?logo=autodesk "Supported MotionBuilder versions")
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-motionbuilder?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=79&branchName=master)
 [![Code style: black](https://img.shields.io/badge/Code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -22,9 +22,9 @@ import pyfbsdk
 import sgtk
 
 # MotionBuilder versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = 2022
-VERSION_OLDEST_SUPPORTED = 2023
-VERSION_NEWEST_SUPPORTED = 2026
+VERSION_OLDEST_COMPATIBLE = 2023
+VERSION_OLDEST_SUPPORTED = 2024
+VERSION_NEWEST_SUPPORTED = 2027
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
 # is equal to VERSION_NEWEST_SUPPORTED
 

--- a/info.yml
+++ b/info.yml
@@ -34,7 +34,7 @@ configuration:
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recommended that you set this
                         value to the current major version + 1.
-        default_value:  2026
+        default_value:  2027
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
This pull request updates the supported versions for MotionBuilder, VFX Reference Platform, and Python in the toolkit engine, bringing compatibility and documentation up to date for the latest releases. The changes ensure the engine remains current with industry standards and communicates accurate support information to users.

**Version Support Updates:**

* Updated version constants in `engine.py` to set `VERSION_OLDEST_COMPATIBLE` to 2023, `VERSION_OLDEST_SUPPORTED` to 2024, and `VERSION_NEWEST_SUPPORTED` to 2027, reflecting support for newer MotionBuilder versions.
* Changed the default value for `compatibility_dialog_min_version` in `info.yml` from 2026 to 2027 to match the updated compatibility window.

**Documentation Updates:**

* Updated badges in `README.md` to show support for MotionBuilder 2024–2027, VFX Reference Platform CY2022–CY2026, and Python 3.9, 3.10, 3.11, and 3.13, ensuring users see up-to-date compatibility at a glance.